### PR TITLE
Scope matches to desc_id/doc when desc_id passed.

### DIFF
--- a/blake_superfast.py
+++ b/blake_superfast.py
@@ -5,9 +5,16 @@ Exports text fragments from matching documents from a Superfastmatch API.
 
 Standard usage: blake_superfast.py
 
-Scoped usage: blake_superfast.py [desc_id]
+Scoped usage: blake_superfast.py [desc_id_fragment]
+Only considers matches if one of the documents begins with desc_id_fragment
     e.g.: blake_superfast.py jerusalem.e.illbk.85
-Looks for matches only between the desc_id document and (all) other documents.
+        Finds matches between jerusalem.e.illbk.85 and any other document
+    e.g.: blake_superfast.py jerusalem.e
+        Find matches between any jerusalem.e document and any other document
+Documents must begin with the given desc_id_fragment, not merely contain it.
+So, `blake_superfast.py e.illbk` would not consider "jerusalem.e.illbk.*" a
+matching document.
+
 """
 
 import sys
@@ -377,14 +384,21 @@ if __name__ == '__main__':
     matrix_relations_file = 'blake-relations.csv'
     print('Exporting matches/fragments to: ' + outfile)
 
-    # If a command line argument is given, take it to be a desc_id, and
-    # look find matches only between that document/desc_id and other documents.
+    # If a command line argument is given, take it to be a desc_id fragment,
+    # and find matches only between 1) documents that begin with that desc_id
+    # fragment and 2) other documents
     if len(sys.argv) > 2:
         raise ValueError("Too many arguments passed from the command line.")
     elif len(sys.argv) == 2:
         desc_id = sys.argv[1]
-        print('Finding matches only for documents with desc_id: ' + desc_id)
-        iterator = [doc for doc in API.documents() if doc.desc_id == desc_id]
+        print('Finding matches only for documents with '
+              'desc_id beginning: ' + desc_id)
+        iterator = [doc for doc in API.documents()
+                    if doc.desc_id.startswith(desc_id)]
+        if not iterator:
+            print('No documents have desc_id beginning: ' + desc_id)
+            print('Exiting.')
+            sys.exit()
     else:
         iterator = API.documents()
 

--- a/blake_superfast.py
+++ b/blake_superfast.py
@@ -1,4 +1,16 @@
 #!/usr/bin/env python
+
+"""
+Exports text fragments from matching documents from a Superfastmatch API.
+
+Standard usage: blake_superfast.py
+
+Scoped usage: blake_superfast.py [desc_id]
+    e.g.: blake_superfast.py jerusalem.e.illbk.85
+Looks for matches only between the desc_id document and (all) other documents.
+"""
+
+import sys
 import csv
 import time
 import simplejson as json
@@ -364,9 +376,21 @@ if __name__ == '__main__':
     outfile = 'blake_superfast_matches.csv'
     matrix_relations_file = 'blake-relations.csv'
     print('Exporting matches/fragments to: ' + outfile)
+
+    # If a command line argument is given, take it to be a desc_id, and
+    # look find matches only between that document/desc_id and other documents.
+    if len(sys.argv) > 2:
+        raise ValueError("Too many arguments passed from the command line.")
+    elif len(sys.argv) == 2:
+        desc_id = sys.argv[1]
+        print('Finding matches only for documents with desc_id: ' + desc_id)
+        iterator = [doc for doc in API.documents() if doc.desc_id == desc_id]
+    else:
+        iterator = API.documents()
+
     try:
         API.export_fragments(
-            outfile, matrix_csv_path=matrix_relations_file
+            outfile, iterator=iterator, matrix_csv_path=matrix_relations_file
         )
     except FileNotFoundError:
         print('Exclude/matrix_relations file not found. Not excluding matches '


### PR DESCRIPTION
e.g. `blake_superfast.py jerusalem.e.illbk.85` will only look for matches between jerusalem.e.illbk.85 and other documents